### PR TITLE
#5 - Fix build

### DIFF
--- a/clients/eclipse/org.apache.camel.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
+++ b/clients/eclipse/org.apache.camel.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.assertj;bundle-version="1.7.1",
- org.eclipse.lsp4e;bundle-version="0.5.0",
+ org.eclipse.lsp4e;bundle-version="0.3.0",
  org.apache.camel.lsp.eclipse.client;bundle-version="1.0.0"

--- a/clients/eclipse/org.apache.camel.lsp.eclipse.client/META-INF/MANIFEST.MF
+++ b/clients/eclipse/org.apache.camel.lsp.eclipse.client/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.lsp4e;bundle-version="0.3.0",
  org.eclipse.core.runtime
 Export-Package: org.apache.camel.lsp.eclipse.client;x-friends:="org.apache.camel.lsp.eclipse.client.tests.integration"
+Eclipse-BundleShape: dir


### PR DESCRIPTION
- current TP is based on lsp4e 0.3.0
- the pugin need to be used as a directory and not packaged as jar to
access the Camel LSP jar more easily

Signed-off-by: Aurélien Pupier <apupier@redhat.com>