### PR TITLE
Provide Camel component Syntax completion

### DIFF
--- a/clients/eclipse/org.apache.camel.lsp.eclipse.client.tests.integration/src/main/java/org/apache/camel/lsp/eclipse/client/tests/integration/CamelLSPStreamConnectionProviderIT.java
+++ b/clients/eclipse/org.apache.camel.lsp.eclipse.client.tests.integration/src/main/java/org/apache/camel/lsp/eclipse/client/tests/integration/CamelLSPStreamConnectionProviderIT.java
@@ -33,10 +33,14 @@ public class CamelLSPStreamConnectionProviderIT {
 		InputStream inputStream = provider.getInputStream();
 		assertThat(inputStream).isNotNull();
 		byte[] buffer = new byte[1024];
-		assertThat(inputStream.read(buffer)).isNotEqualTo(-1);
-		assertThat(new String(buffer)).contains("Connected to Language Server...");
-		
+		boolean isConnected = false;
+		int time = 0;
+		while (!isConnected && time  < 10000 && inputStream.read(buffer) != -1) {
+			isConnected = new String(buffer).contains("Connected to Language Server...");
+			time += 1000;
+		}
 		provider.stop();
+		assertThat(isConnected).isTrue();
 	}
 	
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -49,6 +49,11 @@
 			<version>1.7.6</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-catalog</artifactId>
+			<version>2.20.1</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/CamelLanguageServer.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/CamelLanguageServer.java
@@ -30,8 +30,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.WorkspaceService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * this is the actual server implementation
@@ -40,8 +38,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CamelLanguageServer extends AbstractLanguageServer implements LanguageServer, LanguageClientAware {
 	
-	/** The usual Logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CamelLanguageServer.class);
 	public static final String LANGUAGE_ID = "LANGUAGE_ID_APACHE_CAMEL";
 	
 	private LanguageClient client;
@@ -77,8 +73,8 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		InitializeResult result = new InitializeResult();
 		
 		ServerCapabilities capabilities = new ServerCapabilities();
-		capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
-		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","?","&")));
+		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
+		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","?","&", "\"")));
 		
 		result.setCapabilities(capabilities);
 		return CompletableFuture.completedFuture(result);

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/CamelTextDocumentService.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/CamelTextDocumentService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.camel.tools.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
@@ -63,7 +64,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(TextDocumentPositionParams completionRequest) {
 		LOGGER.info("completion: " + completionRequest.getTextDocument().getUri());
 		TextDocumentItem textDocumentItem = openedDocuments.get(completionRequest.getTextDocument().getUri());
-		return new CamelEndpointCompletionProcessor(textDocumentItem).getCompletions();
+		return new CamelEndpointCompletionProcessor(textDocumentItem).getCompletions(completionRequest.getPosition()).thenApply(Either::forLeft);
 	}
 
 	@Override

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/completion/CamelEndpointCompletionProcessor.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/completion/CamelEndpointCompletionProcessor.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.tools.lsp.internal;
+package org.apache.camel.tools.lsp.internal.completion;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,10 +26,11 @@ import java.util.concurrent.CompletableFuture;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -39,29 +39,49 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class CamelEndpointCompletionProcessor {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelEndpointCompletionProcessor.class);
 	private static final String NAMESPACEURI_CAMEL_BLUEPRINT = "http://camel.apache.org/schema/blueprint";
 	private static final String NAMESPACEURI_CAMEL_SPRING = "http://camel.apache.org/schema/spring";
 	private TextDocumentItem textDocumentItem;
+	private CompletableFuture<CamelCatalog> camelCatalog;
 
 	public CamelEndpointCompletionProcessor(TextDocumentItem textDocumentItem) {
 		this.textDocumentItem = textDocumentItem;
+		camelCatalog = CompletableFuture.supplyAsync(() -> {
+			DefaultCamelCatalog res = new DefaultCamelCatalog(true);
+			res.loadVersion("2.20.1");
+			return res;
+		});
 	}
 
-	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletions() {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
 		if(textDocumentItem != null) {
 			try {
-				if(getCorrespondingCamelNodeForCompletion(textDocumentItem) != null) {
-					return CompletableFuture.completedFuture(Either.forLeft(Arrays.asList(new CompletionItem("dummyCamelCompletion"))));
+				if(getCorrespondingCamelNodeForCompletion(textDocumentItem) != null && isBetweenUriQuote(textDocumentItem, position)) {
+					return camelCatalog.thenApply(new CompletionsFuture());
 				}
 			} catch (Exception e) {
 				LOGGER.error("Error searching for corresponding node elements", e);
 			}
 		}
-		return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
+		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
-	
+
+	private boolean isBetweenUriQuote(TextDocumentItem textDocumentItem, Position position) {
+		String text = textDocumentItem.getText();
+		String[] lines = text.split("\r?\n", position.getLine());
+		if(lines.length == position.getLine() + 1) {
+			String line = lines[position.getLine()];
+			int uriAttribute = line.indexOf("uri=\"");
+			if(uriAttribute != -1) {
+				int nextQuote = line.indexOf('\"', uriAttribute +5);
+				return nextQuote != -1 && position.getCharacter() <= nextQuote && position.getCharacter() >= uriAttribute + 5;
+			}
+		}
+		return false;
+	}
+
 	/**
 	 * @param textDocumentItem
 	 * @return Currently returns the first from Camel Node ignoring the exact position
@@ -73,7 +93,14 @@ public class CamelEndpointCompletionProcessor {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		dbf.setNamespaceAware(true);
 		Document xmlParsed = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(textDocumentItem.getText().getBytes(StandardCharsets.UTF_8)));
-		NodeList childNodes = xmlParsed.getElementsByTagName("from");
+		Node res = getFirstChildFromCamelNameSpaces(xmlParsed.getElementsByTagName("from"));
+		if (res == null) {
+			res = getFirstChildFromCamelNameSpaces(xmlParsed.getElementsByTagName("to"));
+		}
+		return res;
+	}
+
+	private Node getFirstChildFromCamelNameSpaces(NodeList childNodes) {
 		for (int i = 0; i < childNodes.getLength(); i++) {
 			Node child = childNodes.item(i);
 			if (NAMESPACEURI_CAMEL_BLUEPRINT.equals(child.getNamespaceURI()) || NAMESPACEURI_CAMEL_SPRING.equals(child.getNamespaceURI())) {

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/completion/CompletionsFuture.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/completion/CompletionsFuture.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.completion;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.tools.lsp.internal.model.ComponentModel;
+import org.apache.camel.tools.lsp.internal.model.util.ModelHelper;
+import org.eclipse.lsp4j.CompletionItem;
+
+final class CompletionsFuture implements Function<CamelCatalog, List<CompletionItem>> {
+	@Override
+	public List<CompletionItem> apply(CamelCatalog catalog) {
+		return catalog.findComponentNames().stream()
+				.map(componentName -> {
+					ComponentModel componentModel = ModelHelper.generateComponentModel(catalog.componentJSonSchema(componentName), true);
+					return componentModel.getSyntax();
+				})
+				.map(CompletionItem::new).collect(Collectors.toList());
+	}
+}

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/model/ComponentModel.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/model/ComponentModel.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ComponentModel {
+
+    private String kind;
+    private String scheme;
+    private String syntax;
+    private String alternativeSyntax;
+    private String alternativeSchemes;
+    private String title;
+    private String description;
+    private String label;
+    private String deprecated;
+    private String consumerOnly;
+    private String producerOnly;
+    private String javaType;
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private final List<ComponentOptionModel> componentOptions = new ArrayList<>();
+    private final List<EndpointOptionModel> endpointOptions = new ArrayList<>();
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void setSyntax(String syntax) {
+        this.syntax = syntax;
+    }
+
+    public String getAlternativeSyntax() {
+        return alternativeSyntax;
+    }
+
+    public void setAlternativeSyntax(String alternativeSyntax) {
+        this.alternativeSyntax = alternativeSyntax;
+    }
+
+    public String getAlternativeSchemes() {
+        return alternativeSchemes;
+    }
+
+    public void setAlternativeSchemes(String alternativeSchemes) {
+        this.alternativeSchemes = alternativeSchemes;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(String deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getConsumerOnly() {
+        return consumerOnly;
+    }
+
+    public void setConsumerOnly(String consumerOnly) {
+        this.consumerOnly = consumerOnly;
+    }
+
+    public String getProducerOnly() {
+        return producerOnly;
+    }
+
+    public void setProducerOnly(String producerOnly) {
+        this.producerOnly = producerOnly;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public void setJavaType(String javaType) {
+        this.javaType = javaType;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public List<ComponentOptionModel> getComponentOptions() {
+        return componentOptions;
+    }
+
+    public void addComponentOption(ComponentOptionModel option) {
+        componentOptions.add(option);
+    }
+
+    public List<EndpointOptionModel> getEndpointOptions() {
+        return endpointOptions;
+    }
+
+    public void addEndpointOption(EndpointOptionModel option) {
+        endpointOptions.add(option);
+    }
+
+    public ComponentOptionModel getComponentOption(String name) {
+        return componentOptions.stream().filter(o -> o.getName().equals(name)).findFirst().orElse(null);
+    }
+
+    public EndpointOptionModel getEndpointOption(String name) {
+        return endpointOptions.stream().filter(o -> o.getName().equals(name)).findFirst().orElse(null);
+    }
+
+}

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/model/ComponentOptionModel.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/model/ComponentOptionModel.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.model;
+
+public class ComponentOptionModel {
+
+    private String name;
+    private String kind;
+    private String group;
+    private String required;
+    private String type;
+    private String javaType;
+    private String deprecated;
+    private String secret;
+    private String description;
+    private String defaultValue;
+    private String enums;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getRequired() {
+        return required;
+    }
+
+    public void setRequired(String required) {
+        this.required = required;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public void setJavaType(String javaType) {
+        this.javaType = javaType;
+    }
+
+    public String getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(String deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getEnums() {
+        return enums;
+    }
+
+    public void setEnums(String enums) {
+        this.enums = enums;
+    }
+
+}

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/model/EndpointOptionModel.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/model/EndpointOptionModel.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.model;
+
+public class EndpointOptionModel {
+
+    private String name;
+    private String kind;
+    private String group;
+    private String label;
+    private String required;
+    private String type;
+    private String javaType;
+    private String enums;
+    private String prefix;
+    private String multiValue;
+    private String deprecated;
+    private String secret;
+    private String defaultValue;
+    private String description;
+    private String enumValues;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getRequired() {
+        return required;
+    }
+
+    public void setRequired(String required) {
+        this.required = required;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public void setJavaType(String javaType) {
+        this.javaType = javaType;
+    }
+
+    public String getEnums() {
+        return enums;
+    }
+
+    public void setEnums(String enums) {
+        this.enums = enums;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getMultiValue() {
+        return multiValue;
+    }
+
+    public void setMultiValue(String multiValue) {
+        this.multiValue = multiValue;
+    }
+
+    public String getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(String deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getEnumValues() {
+        return enumValues;
+    }
+
+    public void setEnumValues(String enumValues) {
+        this.enumValues = enumValues;
+    }
+
+}

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/model/util/ModelHelper.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/model/util/ModelHelper.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.model.util;
+
+import static org.apache.camel.tools.lsp.internal.model.util.StringUtils.getSafeValue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.catalog.JSonSchemaHelper;
+import org.apache.camel.tools.lsp.internal.model.ComponentModel;
+import org.apache.camel.tools.lsp.internal.model.ComponentOptionModel;
+import org.apache.camel.tools.lsp.internal.model.EndpointOptionModel;
+
+public final class ModelHelper {
+
+    private ModelHelper() {
+        // utility class
+    }
+
+    public static ComponentModel generateComponentModel(String json, boolean includeOptions) {
+        List<Map<String, String>> rows = JSonSchemaHelper.parseJsonSchema("component", json, false);
+
+        ComponentModel component = new ComponentModel();
+        component.setScheme(getSafeValue("scheme", rows));
+        component.setSyntax(getSafeValue("syntax", rows));
+        component.setAlternativeSyntax(getSafeValue("alternativeSyntax", rows));
+        component.setAlternativeSchemes(getSafeValue("alternativeSchemes", rows));
+        component.setTitle(getSafeValue("title", rows));
+        component.setDescription(getSafeValue("description", rows));
+        component.setLabel(getSafeValue("label", rows));
+        component.setDeprecated(getSafeValue("deprecated", rows));
+        component.setConsumerOnly(getSafeValue("consumerOnly", rows));
+        component.setProducerOnly(getSafeValue("producerOnly", rows));
+        component.setJavaType(getSafeValue("javaType", rows));
+        component.setGroupId(getSafeValue("groupId", rows));
+        component.setArtifactId(getSafeValue("artifactId", rows));
+        component.setVersion(getSafeValue("version", rows));
+
+        if (includeOptions) {
+            rows = JSonSchemaHelper.parseJsonSchema("componentProperties", json, true);
+            for (Map<String, String> row : rows) {
+                ComponentOptionModel option = new ComponentOptionModel();
+                option.setName(getSafeValue("name", row));
+                option.setKind(getSafeValue("kind", row));
+                option.setGroup(getSafeValue("group", row));
+                option.setRequired(getSafeValue("required", row));
+                option.setType(getSafeValue("type", row));
+                option.setJavaType(getSafeValue("javaType", row));
+                option.setEnums(getSafeValue("enum", row));
+                option.setDeprecated(getSafeValue("deprecated", row));
+                option.setSecret(getSafeValue("secret", row));
+                option.setDefaultValue(getSafeValue("defaultValue", row));
+                option.setDescription(getSafeValue("description", row));
+                component.addComponentOption(option);
+            }
+
+            rows = JSonSchemaHelper.parseJsonSchema("properties", json, true);
+            for (Map<String, String> row : rows) {
+                EndpointOptionModel option = new EndpointOptionModel();
+                option.setName(getSafeValue("name", row));
+                option.setKind(getSafeValue("kind", row));
+                option.setGroup(getSafeValue("group", row));
+                option.setLabel(getSafeValue("label", row));
+                option.setRequired(getSafeValue("required", row));
+                option.setType(getSafeValue("type", row));
+                option.setJavaType(getSafeValue("javaType", row));
+                option.setEnums(getSafeValue("enum", row));
+                option.setPrefix(getSafeValue("prefix", row));
+                option.setMultiValue(getSafeValue("multiValue", row));
+                option.setDeprecated(getSafeValue("deprecated", row));
+                option.setSecret(getSafeValue("secret", row));
+                option.setDefaultValue(getSafeValue("defaultValue", row));
+                option.setDescription(getSafeValue("description", row));
+                component.addEndpointOption(option);
+            }
+        }
+
+        return component;
+    }
+}

--- a/server/src/main/java/org/apache/camel/tools/lsp/internal/model/util/StringUtils.java
+++ b/server/src/main/java/org/apache/camel/tools/lsp/internal/model/util/StringUtils.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal.model.util;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Various utility methods.
+ */
+public final class StringUtils {
+
+    private StringUtils() {
+    }
+
+    /**
+     * Whether to given value has a question mark or not
+     */
+    static boolean hasQuestionMark(String val) {
+        return val != null && val.indexOf('?') > 0;
+    }
+
+    /**
+     * Gets the value as a Camel component name
+     */
+    public static String asComponentName(String val) {
+        if (val == null) {
+            return null;
+        }
+
+        int pos = val.indexOf(':');
+        if (pos > 0) {
+            return val.substring(0, pos);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the value as a Camel language name
+     */
+    public static String asLanguageName(String val) {
+        if (val == null) {
+            return null;
+        }
+
+        if (val.startsWith("tokenize")) {
+            return "tokenize";
+        } else if (val.equals("js") || val.equals("javascript")) {
+            return "javaScript";
+        }
+
+        return val;
+    }
+
+    /**
+     * Gets the value with the key in a safe way, eg returning an empty string if there was no value for the key.
+     */
+    public static String getSafeValue(String key, List<Map<String, String>> rows) {
+        for (Map<String, String> row : rows) {
+            String value = row.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Gets the value with the key in a safe way, eg returning an empty string if there was no value for the key.
+     */
+    public static String getSafeValue(String key, Map<String, String> rows) {
+        String value = rows.get(key);
+        if (value != null) {
+            return value;
+        }
+        return "";
+    }
+
+    /**
+     * To wrap a big line by a separator.
+     *
+     * @param line the big line
+     * @param separator the separator char such as <tt>&</tt>
+     * @param newLine the new line to use when breaking into a new line
+     * @param watermark a watermark to denote the size to cut after
+     */
+    public static String wrapSeparator(String line, String separator, String newLine, int watermark) {
+        StringBuilder sb = new StringBuilder();
+        String[] parts = line.split(separator);
+
+        StringBuilder part = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            String word = parts[i];
+            part.append(word);
+            if (i < parts.length - 1) {
+                part.append(separator);
+            }
+            // did we hit watermark then reset
+            if (part.length() >= watermark) {
+                // move separator to new line
+                String add = part.toString();
+                if (add.endsWith(separator)) {
+                    add = add.substring(0, add.length() - separator.length());
+                }
+                sb.append(add);
+                sb.append(newLine);
+                sb.append(separator);
+                part.setLength(0);
+            }
+        }
+        // any leftover
+        if (part.length() > 0) {
+            sb.append(part.toString());
+        }
+
+        String answer = sb.toString();
+        if (answer.endsWith(newLine)) {
+            answer = answer.substring(0, answer.length() - newLine.length());
+        }
+        return answer;
+    }
+
+    /**
+     * To wrap a big line by words.
+     *
+     * @param line the big line
+     * @param newLine the new line to use when breaking into a new line
+     * @param watermark a watermark to denote the size to cut after
+     * @param wrapLongWords whether to wrap long words
+     */
+    public static String wrapWords(String line, String newLine, int watermark, boolean wrapLongWords) {
+        if (line == null) {
+            return null;
+        } else {
+            if (newLine == null) {
+                newLine = System.lineSeparator();
+            }
+
+            if (watermark < 1) {
+                watermark = 1;
+            }
+
+            int inputLineLength = line.length();
+            int offset = 0;
+            StringBuilder sb = new StringBuilder(inputLineLength + 32);
+
+            while (inputLineLength - offset > watermark) {
+                if (line.charAt(offset) == 32) {
+                    ++offset;
+                } else {
+                    int spaceToWrapAt = line.lastIndexOf(32, watermark + offset);
+                    if (spaceToWrapAt >= offset) {
+                        sb.append(line.substring(offset, spaceToWrapAt));
+                        sb.append(newLine);
+                        offset = spaceToWrapAt + 1;
+                    } else if (wrapLongWords) {
+                        sb.append(line.substring(offset, watermark + offset));
+                        sb.append(newLine);
+                        offset += watermark;
+                    } else {
+                        spaceToWrapAt = line.indexOf(32, watermark + offset);
+                        if (spaceToWrapAt >= 0) {
+                            sb.append(line.substring(offset, spaceToWrapAt));
+                            sb.append(newLine);
+                            offset = spaceToWrapAt + 1;
+                        } else {
+                            sb.append(line.substring(offset));
+                            offset = inputLineLength;
+                        }
+                    }
+                }
+            }
+
+            sb.append(line.substring(offset));
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Is the string empty
+     */
+    public static boolean isEmpty(String str) {
+        return str == null || str.trim().length() == 0;
+    }
+
+    /**
+     * Is the string NOT empty
+     */
+    public static boolean isNotEmpty(String str) {
+        return !isEmpty(str);
+    }
+
+}

--- a/server/src/test/java/org/apache/camel/tools/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/server/src/test/java/org/apache/camel/tools/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -1,0 +1,92 @@
+package org.apache.camel.tools.lsp.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+public abstract class AbstractCamelLanguageServerTest {
+
+	public AbstractCamelLanguageServerTest() {
+		super();
+	}
+	
+	final class DummyLanguageClient implements LanguageClient {
+		@Override
+		public void telemetryEvent(Object object) {
+		}
+
+		@Override
+		public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+			return null;
+		}
+
+		@Override
+		public void showMessage(MessageParams messageParams) {
+		}
+
+		@Override
+		public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+		}
+
+		@Override
+		public void logMessage(MessageParams message) {
+		}
+	}
+
+	protected CamelLanguageServer initializeLanguageServer(String text)
+			throws URISyntaxException, InterruptedException, ExecutionException {
+				InitializeParams params = new InitializeParams();
+				params.setProcessId(new Random().nextInt());
+				params.setRootUri(getTestResource("/workspace/").toURI().toString());
+				CamelLanguageServer camelLanguageServer = new CamelLanguageServer();
+				camelLanguageServer.connect(new DummyLanguageClient());
+				CompletableFuture<InitializeResult> initialize = camelLanguageServer.initialize(params);
+				
+				assertThat(initialize).isCompleted();
+				assertThat(initialize.get().getCapabilities().getCompletionProvider().getResolveProvider()).isTrue();
+				
+				camelLanguageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(createTestTextDocument(text)));
+				
+				return camelLanguageServer;
+			}
+
+	private TextDocumentItem createTestTextDocument(String text) {
+		return new TextDocumentItem("dummyUri", CamelLanguageServer.LANGUAGE_ID, 0, text);
+	}
+
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletionFor(CamelLanguageServer camelLanguageServer, Position position) {
+		TextDocumentService textDocumentService = camelLanguageServer.getTextDocumentService();
+		
+		TextDocumentPositionParams dummyCompletionPositionRequest = new TextDocumentPositionParams(new TextDocumentIdentifier("dummyUri"), position);
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = textDocumentService.completion(dummyCompletionPositionRequest);
+		return completions;
+	}
+
+	public File getTestResource(String name) throws URISyntaxException {
+		return Paths.get(CamelLanguageServerTest.class.getResource(name).toURI()).toFile();
+	}
+
+}

--- a/server/src/test/java/org/apache/camel/tools/lsp/internal/CamelLanguageServerCompletionPositionTest.java
+++ b/server/src/test/java/org/apache/camel/tools/lsp/internal/CamelLanguageServerCompletionPositionTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tools.lsp.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CamelLanguageServerCompletionPositionTest extends AbstractCamelLanguageServerTest {
+	
+	@Parameters(name="{4} - Position ({1},{2})")
+    public static Collection<Object[]> data() {
+    	return Arrays.asList(new Object[][] {
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 0, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 1, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 2, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 3, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 4, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 5, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 6, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 7, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 8, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 9, false, "Empty URI"},
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 10, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 11, true, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 12, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 13, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 14, false, "Empty URI" },
+    		{ "<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 15, false, "Empty URI" },
+
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 10, false, "Uri with some value" },
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 11, true, "Uri with some value" },
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 12, true, "Uri with some value" },
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 13, true, "Uri with some value" },
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 14, true, "Uri with some value" },
+    		{ "<from uri=\"ahc\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n", 0, 15, false, "Uri with some value" }
+    	});
+    }
+    
+    @Parameter
+    public String textToTest;
+    @Parameter(1)
+    public int line;
+    @Parameter(2)
+    public int character;
+    @Parameter(3)
+    public boolean shoudlHaveCompletion;
+    @Parameter(4)
+    public String testNameQualification;
+	
+	@Test
+	public void testProvideCompletionForCamelBlueprintNamespace() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(textToTest);
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(line, character));
+		
+		if(shoudlHaveCompletion) {
+			assertThat(completions.get().getLeft()).contains(new CompletionItem("ahc:httpUri"));
+		} else {
+			assertThat(completions.get().getLeft()).isEmpty();
+			assertThat(completions.get().getRight()).isNull();
+		}
+	}
+}

--- a/server/src/test/java/org/apache/camel/tools/lsp/internal/CamelLanguageServerTest.java
+++ b/server/src/test/java/org/apache/camel/tools/lsp/internal/CamelLanguageServerTest.java
@@ -18,115 +18,62 @@ package org.apache.camel.tools.lsp.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
-import org.eclipse.lsp4j.DidOpenTextDocumentParams;
-import org.eclipse.lsp4j.InitializeParams;
-import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.MessageActionItem;
-import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.ShowMessageRequestParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.TextDocumentItem;
-import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.Test;
 
 
-public class CamelLanguageServerTest {
+public class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 	
-	private final class DummyLanguageClient implements LanguageClient {
-		@Override
-		public void telemetryEvent(Object object) {
-		}
-
-		@Override
-		public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
-			return null;
-		}
-
-		@Override
-		public void showMessage(MessageParams messageParams) {
-		}
-
-		@Override
-		public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
-		}
-
-		@Override
-		public void logMessage(MessageParams message) {
-		}
-	}
-
 	@Test
-	public void testProvideDummyCompletionForCamelBlueprintNamespace() throws Exception {
+	public void testProvideCompletionForCamelBlueprintNamespace() throws Exception {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n");
 		
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 13));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 11));
 		
-		assertThat(completions.get().getLeft()).contains(new CompletionItem("dummyCamelCompletion"));
+		assertThat(completions.get().getLeft()).contains(new CompletionItem("ahc:httpUri"));
 	}
 	
 	@Test
-	public void testProvideDummyCompletionForCamelSpringNamespace() throws Exception {
+	public void testProvideCompletionForToCamelBlueprintNamespace() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<to uri=\"\" xmlns=\"http://camel.apache.org/schema/blueprint\"></to>\n");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 9));
+		
+		assertThat(completions.get().getLeft()).contains(new CompletionItem("ahc:httpUri"));
+	}
+	
+	@Test
+	public void testProvideCompletionForCamelSpringNamespace() throws Exception {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"\" xmlns=\"http://camel.apache.org/schema/spring\"></from>\n");
 		
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 11));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 11));
 		
-		assertThat(completions.get().getLeft()).contains(new CompletionItem("dummyCamelCompletion"));
+		assertThat(completions.get().getLeft()).contains(new CompletionItem("ahc:httpUri"));
 	}
 
 	@Test
-	public void testDONTProvideDummyCompletionForNotCamelnamespace() throws Exception {
+	public void testDONTProvideCompletionForNotCamelnamespace() throws Exception {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"\"></from>\n");
 		
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 11));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 11));
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 		assertThat(completions.get().getRight()).isNull();
 	}
-
-	private CamelLanguageServer initializeLanguageServer(String text) throws URISyntaxException, InterruptedException, ExecutionException {
-		InitializeParams params = new InitializeParams();
-		params.setProcessId(new Random().nextInt());
-		params.setRootUri(getTestResource("/workspace/").toURI().toString());
-		CamelLanguageServer camelLanguageServer = new CamelLanguageServer();
-		camelLanguageServer.connect(new DummyLanguageClient());
-		CompletableFuture<InitializeResult> initialize = camelLanguageServer.initialize(params);
-		
-		assertThat(initialize).isCompleted();
-		assertThat(initialize.get().getCapabilities().getCompletionProvider().getResolveProvider()).isTrue();
-		
-		camelLanguageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(createTestTextDocument(text)));
-		
-		return camelLanguageServer;
-	}
-
-	private TextDocumentItem createTestTextDocument(String text) {
-		return new TextDocumentItem("dummyUri", CamelLanguageServer.LANGUAGE_ID, 0, text);
-	}
 	
-	private CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletionFor(CamelLanguageServer camelLanguageServer, Position position) {
-		TextDocumentService textDocumentService = camelLanguageServer.getTextDocumentService();
+	@Test
+	public void testDONTProvideCompletionWhenNotAfterURIEqualQuote() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"\" xmlns=\"http://camel.apache.org/schema/spring\"></from>\n");
 		
-		TextDocumentPositionParams dummyCompletionPositionRequest = new TextDocumentPositionParams(new TextDocumentIdentifier("dummyUri"), position);
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = textDocumentService.completion(dummyCompletionPositionRequest);
-		return completions;
-	}
-	
-	public File getTestResource(String name) throws URISyntaxException {
-		return Paths.get(CamelLanguageServerTest.class.getResource(name).toURI()).toFile();
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 6));
+		
+		assertThat(completions.get().getLeft()).isEmpty();
+		assertThat(completions.get().getRight()).isNull();
 	}
 }


### PR DESCRIPTION
- provide syntax completion when:
-- after 'uri="' and before next '"'
-- there is at least one to or from part of camel namespace in the
document
- duplicated (ouch) Model and some Model Helper from Camel IntelliJ
plugin

Signed-off-by: Aurélien Pupier <apupier@redhat.com>